### PR TITLE
fix safari library scroll not working

### DIFF
--- a/src/editor/components/LibraryPanel.vue
+++ b/src/editor/components/LibraryPanel.vue
@@ -554,10 +554,18 @@ export default {
 	}
 
 	&-column-wrapper {
-		position: relative;
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
 		overflow-x: hidden;
+		width: 100%;
 		height: 100%;
-		padding: 0 20px;
+		height: 100%;
+		min-height: 300px;
+		padding: 0 20px 80px 20px;
+		transform: translateY(80px);
 
 		p.znpb-editor-library-modal-no-more {
 			margin-bottom: 40px;

--- a/src/scss/_scrollbar.scss
+++ b/src/scss/_scrollbar.scss
@@ -6,14 +6,17 @@
 	overflow-x: hidden;
 	overflow-y: auto;
 
+	-webkit-overflow-scrolling: touch;
+
 	.znpb-fancy-scrollbar &::-webkit-scrollbar-thumb {
+		display: block;
 		background: transparent;
 	}
 }
 
 /* Track */
 .znpb-fancy-scrollbar::-webkit-scrollbar-track {
-	// background: $surface-variant;
+	display: block;
 	background: transparent;
 }
 


### PR DESCRIPTION
add display block for thumb scrolling bar (this is disabled on safari)
make library column wrapper position absolute 