### PR TITLE
fix grid gradient library overflow

### DIFF
--- a/packages/components/src/components/Colorpicker/GridColor.vue
+++ b/packages/components/src/components/Colorpicker/GridColor.vue
@@ -30,6 +30,12 @@ export default {
 	grid-row-gap: 10px;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
 	justify-items: center;
+
+	&--no-pd {
+		padding: 0;
+		margin: 0;
+	}
+
 	.znpb-colorpicker-add-color {
 		box-sizing: content-box;
 		width: 26px;

--- a/packages/components/src/components/Gradient/GradientLibrary.vue
+++ b/packages/components/src/components/Gradient/GradientLibrary.vue
@@ -6,7 +6,7 @@
 	>
 		<Tabs tab-style="minimal">
 			<Tab name="Local">
-				<div class=" znpb-form-library-grid__panel-content znpb-fancy-scrollbar">
+				<div class="znpb-form-library-grid__panel-content znpb-form-library-grid__panel-content--no-pd znpb-fancy-scrollbar">
 					<GradientPreview
 						v-for="(gradient,i) in getLocalGradients"
 						v-bind:key="i"
@@ -30,7 +30,7 @@
 					/>
 				</div>
 				<template v-else>
-					<div class="znpb-form-library-grid__panel-content znpb-fancy-scrollbar">
+					<div class="znpb-form-library-grid__panel-content znpb-form-library-grid__panel-content--no-pd znpb-fancy-scrollbar">
 						<GradientPreview
 							v-for="(gradient,i) in getGlobalGradients"
 							v-bind:key="i"


### PR DESCRIPTION
add exra class with no padding and no margin as the same class is also used on colors library