### PR TITLE
Fixed plugin name display

### DIFF
--- a/zionbuilder.php
+++ b/zionbuilder.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: ZionBuilder
+Plugin Name: Zion Builder
 Plugin URI: https://zionbuilder.io/?utm_campaign=plugin-uri&utm_medium=wp-dashboard-plugins
 Description: The page builder you always wanted. Create any design you want using live editor.
 Version: 1.2.2


### PR DESCRIPTION
The names was showing as ZionBuilder instead of Zion Builder