### PR TITLE
Disabled nonce verification on edit page

### DIFF
--- a/includes/Editor/Editor.php
+++ b/includes/Editor/Editor.php
@@ -52,11 +52,6 @@ class Editor {
 	 * @return void
 	 */
 	public function init() {
-		// Verify nonce
-		if ( ! Nonces::verify_nonce( Nonces::ACTIVE_EDITOR ) ) {
-			return;
-		}
-
 		// Get the post id
 		$post_id = isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : false; // phpcs:ignore WordPress.Security.NonceVerification
 

--- a/includes/Post/BasePostType.php
+++ b/includes/Post/BasePostType.php
@@ -213,9 +213,8 @@ class BasePostType {
 	public function get_edit_url() {
 		$url = add_query_arg(
 			[
-				'post_id'              => absint( $this->get_post_id() ),
-				'action'               => 'zion_builder_active',
-				Nonces::NONCE_FIELD_ID => Nonces::generate_nonce( Nonces::ACTIVE_EDITOR ),
+				'post_id' => absint( $this->get_post_id() ),
+				'action'  => 'zion_builder_active',
 			],
 			admin_url( 'post.php' )
 		);

--- a/languages/zionbuilder.pot
+++ b/languages/zionbuilder.pot
@@ -2028,7 +2028,7 @@ msgid "Edit with "
 msgstr ""
 
 #. translators: %s: The username who is locked from editing
-#: ../includes/Editor/Editor.php:267
+#: ../includes/Editor/Editor.php:262
 msgid "Post is locked by %s"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Second argument of add_option must be an array or an instance of ZionBuilder\Options\Option"
 msgstr ""
 
-#: ../includes/Post/BasePostType.php:512
+#: ../includes/Post/BasePostType.php:511
 msgid "Cannot create autosave for post"
 msgstr ""
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,1 +1,1 @@
-{"appName":"zionbuilder","outputDir":"dist","debug":true,"mode":"development","devServer":"http://localhost:53349/"}
+{"appName":"zionbuilder","outputDir":"dist"}


### PR DESCRIPTION
This was not needed as the plugin already checks if the user has rights to edit that page.