### PR TITLE
margin-left: 5px for the green indicator

### DIFF
--- a/packages/components/src/components/ChangesBullet/ChangesBullet.vue
+++ b/packages/components/src/components/ChangesBullet/ChangesBullet.vue
@@ -77,7 +77,7 @@ export default {
 }
 
 .znpb-options-has-changes-wrapper {
-	margin-left: 10px;
+	margin-left: 5px;
 	cursor: pointer;
 	.znpb-options-has-changes-wrapper__delete {
 		stroke: var(--zb-surface-text-active-color);


### PR DESCRIPTION
Reducing the margin of the indicator, so that it is not carried to the next line because of the long text.