### PR TITLE
Reduced the space for discard changes button

### DIFF
--- a/packages/components/src/components/ChangesBullet/ChangesBullet.vue
+++ b/packages/components/src/components/ChangesBullet/ChangesBullet.vue
@@ -68,7 +68,7 @@ export default {
 	height: 100%;
 	background: #31d783;
 	border-radius: 50%;
-	transition: transform 0.15s, background-color 0.1s;
+	transition: transform .15s, background-color .1s;
 }
 
 .znpb-options__has-changes:hover::after {
@@ -77,12 +77,13 @@ export default {
 }
 
 .znpb-options-has-changes-wrapper {
-	margin-left: 10px;
+	margin-left: 5px;
 	cursor: pointer;
 	.znpb-options-has-changes-wrapper__delete {
-		stroke: var(--zb-surface-text-active-color);
 		z-index: 9;
 		justify-content: center;
+
+		stroke: var(--zb-surface-text-active-color);
 		.zion-svg-inline {
 			margin: 0;
 		}


### PR DESCRIPTION
This is the same code change from https://github.com/zionbuilder/zionbuilder/pull/601

I have changed the base branch to develop in order to keep the master branch free for quick fixes