### PR TITLE
Upgrade Nodejs in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v1.4.2
         with:
-            node-version: '12'
+            node-version: '14'
       - name: Set Composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-dir)"


### PR DESCRIPTION
It was not successful in last 7 months.
Is it still necessary?

From https://github.com/zionbuilder/zionbuilder/actions/runs/3279712909/jobs/5399603942
